### PR TITLE
Add localisation to player icon settings and forms

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -13,6 +13,10 @@
     "SETTINGS.DefaultJournalPermissionH": "The default permission journal entries will be created with",
     "SETTINGS.DefaultJournalFolderN": "Default Journal Entry Folder",
     "SETTINGS.DefaultJournalFolderH": "The default folder journal entries will be created in when creating Map Pins with a double-click",
+    "SETTINGS.PlayerIconAutoOverrideN": "Enable Player-Only Icons by default",
+    "SETTINGS.PlayerIconAutoOverrideH": "Newly created notes will have player-only icons enabled automatically.",
+    "SETTINGS.PlayerIconPathDefaultN": "Default Note Icon for Players",
+    "SETTINGS.PlayerIconPathDefaultH": "The default icon used for player-only icons",
 
     "PinCushion": {
         "Name": "Name:",
@@ -21,8 +25,13 @@
         "Folder": "Journal Entry Folder:",
         "ExistingFolders": "Existing Folders",
         "DefaultPermission": "Default Permission (for all players):",
+
         "CreateMissingFoldersT": "Create Missing Folders",
         "CreateMissingFoldersC": "<b>Create a Journal Entry folder for each player?</b><br>This ensures that each player has their own folder for entries to be created in.",
+
+        "UsePlayerIcon": "Use a Player-Only Icon",
+        "PlayerIconHint": "Enable to overide the icon players will see.",
+        "PlayerIconPath": "Player Icon Path",
 
         "Warn": {
             "AllowPlayerNotes": "Players also need the Core Foundry Permission \"{permission}\" to create map pins.",

--- a/pin-cushion.js
+++ b/pin-cushion.js
@@ -245,17 +245,14 @@ class PinCushion {
     static _editNoteConfig(app, html, data) {
         /* Replaces icon selector in Notes Config form with filepicker */
         const filePickerHtml = 
-        `<input type="text" name="icon" title="Icon Path" class="icon-path" value="${data.data.icon}" placeholder="/icons/example.svg" data-dtype="String">
-        <button type="button" name="file-picker" class="file-picker" data-type="image" data-target="icon" title="Browse Files" tabindex="-1">
-        <i class="fas fa-file-import fa-fw"></i>
-        </button>`
+            `<input type="text" name="icon" title="Icon Path" class="icon-path" value="${data.data.icon}" placeholder="/icons/example.svg" data-dtype="String">
+            <button type="button" name="file-picker" class="file-picker" data-type="image" data-target="icon" title="Browse Files" tabindex="-1">
+            <i class="fas fa-file-import fa-fw"></i>
+            </button>`
 
         const iconSelector = html.find("select[name='icon']");
 
         iconSelector.replaceWith(filePickerHtml);
-
-        // Detect and activate file-picker buttons
-        html.find("button.file-picker").on("click", app._activateFilePicker.bind(app));
 
         /* Adds fields to set player-only note icons */
         /* Get default values set by GM */
@@ -268,33 +265,36 @@ class PinCushion {
         /* Set HTML to be added to the note-config */
         const playerIconHtml =
             `<hr>
-<!-- Button to Enable overrides -->
-<div class="form-group">
-<label>Use Player Journal Icons</label>
-<div class="form-fields">
-<input type="checkbox" name="flags.${PinCushion.MODULE_NAME}.PlayerIconState" data-dtype="Boolean" ${state ? 'checked' : ``} />
-</div>
-<p class="notes"> Enable to overide the icon players will see.</p>
-</div>
+            <!-- Button to Enable overrides -->
+            <div class="form-group">
+            <label>${game.i18n.localize("PinCushion.UsePlayerIcon")}</label>
+            <div class="form-fields">
+            <input type="checkbox" name="flags.${PinCushion.MODULE_NAME}.PlayerIconState" data-dtype="Boolean" ${state ? 'checked' : ``} />
+            </div>
+            <p class="notes">${game.i18n.localize("PinCushion.PlayerIconHint")}</p>
+            </div>
+            
+            <!-- Player Icon -->
+            <div class="form-group">
+            <label>${game.i18n.localize("PinCushion.PlayerIconPath")}</label>
+            <!--
+            <div class="form-fields">
+            <select name="icon">
+            </select>
+            -->
+            <input type="text" name="flags.${PinCushion.MODULE_NAME}.PlayerIconPath" title="Icon Path" class="icon-path" value='${path ? path : ``}'
+            data-dtype="String">
+            
+            <button type="button" name="file-picker" class="file-picker" data-type="image" data-target="flags.${PinCushion.MODULE_NAME}.PlayerIconPath"
+            title="Browse Files" tabindex="-1">
+            <i class="fas fa-file-import fa-fw"></i>
+            </button>
+            </div>`;
 
-<!-- Player Icon -->
-<div class="form-group">
-<label>Player Icon Path</label>
-<!--
-<div class="form-fields">
-<select name="icon">
-</select>
--->
-<input type="text" name="flags.${PinCushion.MODULE_NAME}.PlayerIconPath" title="Icon Path" class="icon-path" value='${path ? path : ``}'
-data-dtype="String">
-
-<button type="button" name="file-picker" class="file-picker" data-type="image" data-target="flags.${PinCushion.MODULE_NAME}.PlayerIconPath"
-title="Browse Files" tabindex="-1">
-<i class="fas fa-file-import fa-fw"></i>
-</button>
-</div>`;
-
+        // Insert Player Icon handling at end of config
         html.find('button[name="submit"]').before(playerIconHtml);
+
+        // Detect and activate file-picker buttons
         html.find('button.file-picker').on('click', app._activateFilePicker.bind(app));
 
     }
@@ -302,9 +302,9 @@ title="Browse Files" tabindex="-1">
     /**
      * Defines the icon to be drawn for players if enabled.
      */
-     static _onPrepareNoteData(wrapped) {
+    static _onPrepareNoteData(wrapped) {
         wrapped()
-        
+
         // IF not GM and IF  = enabled then take flag path as note.data.icon
         if (!game.user.isGM && this.data.flags[PinCushion.MODULE_NAME]?.PlayerIconState) {
             this.data.icon = this.data.flags[PinCushion.MODULE_NAME]?.PlayerIconPath
@@ -488,21 +488,21 @@ title="Browse Files" tabindex="-1">
             }
         });
 
-        game.settings.register(PinCushion.MODULE_NAME, 'playerIconAutoOverride', {
-            name: 'Enable player-only note icons by default',
-            hint: 'Newly created notes will be enabled automatically.',
-            scope: 'world',
+        game.settings.register(PinCushion.MODULE_NAME, "playerIconAutoOverride", {
+            name: "SETTINGS.PlayerIconAutoOverrideN",
+            hint: "SETTINGS.PlayerIconAutoOverrideH",
+            scope: "world",
             config: true,
             default: false,
             type: Boolean
         });
 
-        game.settings.register(PinCushion.MODULE_NAME, 'playerIconPathDefault', {
-            name: 'Default player note icon',
-            hint: 'The default icon for player notes',
-            scope: 'world',
+        game.settings.register(PinCushion.MODULE_NAME, "playerIconPathDefault", {
+            name: "SETTINGS.PlayerIconPathDefaultN",
+            hint: "SETTINGS.PlayerIconPathDefaultH",
+            scope: "world",
             config: true,
-            default: `icons/svg/book.svg`,
+            default: "icons/svg/book.svg",
             type: String,
             filePicker: true,
         });


### PR DESCRIPTION
This enables localisation for the newly added Player Icon related options.
I tried to improve the wording (and shorten one option name to make it fit on one line), but whether I succeeded in that is left open to the reader.
Should there be a better, more intelligible, or more concise wording, I'd encourage whoever comes up with one to go for it.

In case of mistakes, I'm sorry for any inconvenience – please do feel free to just correct them.